### PR TITLE
Add space between Word components being rendered

### DIFF
--- a/src/component/text/Text.tsx
+++ b/src/component/text/Text.tsx
@@ -15,7 +15,7 @@ export const Text = (props: Props) => {
         key={index}
         onCurrentWord={index === props.currentWordIndex}
         onPastWords={index < props.currentWordIndex}
-        word={word}
+        word={word + " "}
         currentWordSubstring={props.currentWordSubstring}
         input={props.input}
       />

--- a/src/component/text/Word.tsx
+++ b/src/component/text/Word.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { Letter } from "./Letter";
-import "./css/Word.css";
 
 interface Props {
   word: String;
@@ -38,5 +37,5 @@ export const Word = (props: Props) => {
     }
   };
 
-  return <span className="Word">{generateLetters()}</span>;
+  return <span>{generateLetters()}</span>;
 };

--- a/src/component/text/css/Word.css
+++ b/src/component/text/css/Word.css
@@ -1,4 +1,0 @@
-.Word {
-  padding-right: 2px;
-  padding-left: 2px;
-}


### PR DESCRIPTION
The 3.5 month old conundrum of "How do we add spaces between our Word
components?" has been solved.

Previously it had been achieved with padding each letter left and right
to simulate spaces.

Now that CSS is being learned, text-wrap was just not happening with
padding, as spaces didn't exist, so words were breaking in the middle.