### PR TITLE
Add routing

### DIFF
--- a/src/component/App.tsx
+++ b/src/component/App.tsx
@@ -1,39 +1,18 @@
 import * as React from "react";
-import { useState } from "react";
-import { SignOn } from "./welcome/SignOn";
-import { SlackButton } from "./slack/SlackButton";
-import { Authenticate } from "./slack/Authenticate";
-import * as slack from "./slack/api/handleSlackOAuth";
-import "./css/App.css";
+import { BrowserRouter as Router, Route, Link } from "react-router-dom";
+import { Authentication } from "./Authentication";
+import { Stats } from "./globalstats/Stats";
 
-export const App = () => {
-  const [authenticated, setAuthenticated] = useState<boolean>(false);
+export const App = () => (
+  <Router>
+    <div>
+      <nav>
+        <Link to="/stats">Stats</Link>
+      </nav>
 
-  const slackSignIn = () => {
-    var entryURL = "http://" + window.location.host + window.location.pathname;
-
-    window.location.href =
-      "https://slack.com/oauth/authorize?scope=identity.basic&client_id=708370195111.695122331683&redirect_uri=" +
-      entryURL +
-      "&state=goodtimes";
-  };
-
-  return (
-    <div className="app">
-      <div className="app__title">Welcome to Homerow Brawl</div>
-      <div className="app__bottom">
-        <div className="app__bottom--button">
-          {!sessionStorage.getItem("authenticated") &&
-            window.location.href.length < 45 && (
-              <SlackButton handleEvent={slackSignIn} />
-            )}
-        </div>
-        {!sessionStorage.getItem("authenticated") &&
-          slack.handleURL(setAuthenticated)}
-        {!sessionStorage.getItem("authenticated") &&
-          window.location.href.length > 45 && <Authenticate />}
-        {sessionStorage.getItem("authenticated") && <SignOn />}
-      </div>
+      <Route path="/stats/" component={Stats} />
+      <Route path="/" exact component={Authentication} />
+      <Route path="/:id(\d+)" exact component={Authentication} />
     </div>
-  );
-};
+  </Router>
+);

--- a/src/component/Authentication.tsx
+++ b/src/component/Authentication.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { useState } from "react";
+import { SignOn } from "./welcome/SignOn";
+import { SlackButton } from "./slack/SlackButton";
+import { Authenticate } from "./slack/Authenticate";
+import * as slack from "./slack/api/handleSlackOAuth";
+import "./css/Authentication.css";
+
+export const Authentication = () => {
+  const [authenticated, setAuthenticated] = useState<boolean>(false);
+
+  const slackSignIn = () => {
+    var entryURL = "http://" + window.location.host + window.location.pathname;
+
+    window.location.href =
+      "https://slack.com/oauth/authorize?scope=identity.basic&client_id=708370195111.695122331683&redirect_uri=" +
+      entryURL +
+      "&state=goodtimes";
+  };
+
+  return (
+    <div className="authentication">
+      <div className="authentication__title">Welcome to Homerow Brawl</div>
+      <div className="authentication__bottom">
+        <div className="authentication__bottom--button">
+          {!sessionStorage.getItem("authenticated") &&
+            window.location.href.length < 45 && (
+              <SlackButton handleEvent={slackSignIn} />
+            )}
+        </div>
+        {!sessionStorage.getItem("authenticated") &&
+          slack.handleURL(setAuthenticated)}
+        {!sessionStorage.getItem("authenticated") &&
+          window.location.href.length > 45 && <Authenticate />}
+        {sessionStorage.getItem("authenticated") && <SignOn />}
+      </div>
+    </div>
+  );
+};

--- a/src/component/__tests__/App.test.tsx
+++ b/src/component/__tests__/App.test.tsx
@@ -9,7 +9,6 @@ describe("App", () => {
   it("renders without crashing", () => {
     const wrapper = mount(<App />);
 
-    expect(wrapper.find("WebsocketController").length).toEqual(0);
-    expect(wrapper.find("Welcome").length).toEqual(0);
+    expect(wrapper.find("Authentication").length).toEqual(1);
   });
 });

--- a/src/component/__tests__/Authenticate.test.tsx
+++ b/src/component/__tests__/Authenticate.test.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { mount, configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import { Authentication } from "../Authentication";
+
+configure({ adapter: new Adapter() });
+
+describe("Authentication", () => {
+  it("renders without crashing", () => {
+    const wrapper = mount(<Authentication />);
+
+    expect(wrapper.find("WebsocketController").length).toEqual(0);
+    expect(wrapper.find("Welcome").length).toEqual(0);
+  });
+});

--- a/src/component/css/Authentication.css
+++ b/src/component/css/Authentication.css
@@ -1,10 +1,10 @@
-.app {
+.authentication {
   margin: 2%;
   border: 2px solid red;
   height: 55em;
 }
 
-.app__title {
+.authentication__title {
   text-align: center;
   font-size: 32pt;
   margin-left: auto;
@@ -14,7 +14,7 @@
   padding: 5%;
 }
 
-.app__bottom {
+.authentication__bottom {
   margin-left: auto;
   margin-right: auto;
   border: 5px solid blue;
@@ -22,6 +22,6 @@
   width: 75%;
 }
 
-.app__bottom--button {
+.authentication__bottom--button {
   text-align: center;
 }

--- a/src/component/globalstats/Stats.tsx
+++ b/src/component/globalstats/Stats.tsx
@@ -1,0 +1,2 @@
+import * as React from "react";
+export const Stats = () => <>place stats here</>;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="react-scripts" />
 declare module "react-websocket";
+declare module "react-router-dom";


### PR DESCRIPTION
This was extremely smooth to implement. When a player enters the
application from "/" as before, they are able to authenticate, create a
game room, and play the game.

When a player enters from a link to a game room, they are able to
authenticate and play as expected.

There will now be a Stats button that pulls you away from the game
to a separate page without causing a refresh as that's how react-router
works. You are still able to get back to the game and this surprisingly
works very smoothly.

Requests to the server for rooms also only happen when you are
redirected to the Authentication component from "/" or "/:room_id".