### PR TITLE
Add stats page

### DIFF
--- a/src/component/App.tsx
+++ b/src/component/App.tsx
@@ -3,16 +3,20 @@ import { BrowserRouter as Router, Route, Link } from "react-router-dom";
 import { Authentication } from "./Authentication";
 import { Stats } from "./globalstats/Stats";
 
-export const App = () => (
-  <Router>
-    <div>
-      <nav>
-        <Link to="/stats">Stats</Link>
-      </nav>
+export const App = () => {
+  return (
+    <>
+      <Router>
+        <div>
+          <nav>
+            <Link to="/stats">Stats</Link>
+          </nav>
 
-      <Route path="/stats/" component={Stats} />
-      <Route path="/" exact component={Authentication} />
-      <Route path="/:id(\d+)" exact component={Authentication} />
-    </div>
-  </Router>
-);
+          <Route path="/stats/" component={Stats} />
+          <Route path="/" exact component={Authentication} />
+          <Route path="/:id(\d+)" exact component={Authentication} />
+        </div>
+      </Router>
+    </>
+  );
+};

--- a/src/component/__tests__/App.test.tsx
+++ b/src/component/__tests__/App.test.tsx
@@ -1,14 +1,53 @@
 import * as React from "react";
 import { mount, configure } from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
+import { MemoryRouter } from "react-router-dom";
+import { Stats } from "../globalstats/Stats";
+import { Authentication } from "../Authentication";
 import { App } from "../App";
+import Adapter from "enzyme-adapter-react-16";
 
 configure({ adapter: new Adapter() });
 
-describe("App", () => {
-  it("renders without crashing", () => {
-    const wrapper = mount(<App />);
+// jest.mock("firebase/app");
 
-    expect(wrapper.find("Authentication").length).toEqual(1);
+describe("App", () => {
+  it("renders the Stats component", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={["/stats"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(wrapper.find(Authentication)).toHaveLength(0);
+    expect(wrapper.find(Stats)).toHaveLength(1);
+  });
+
+  it("renders Authentication without a room", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={["/"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(wrapper.find(Authentication)).toHaveLength(1);
+    expect(wrapper.find(Stats)).toHaveLength(0);
+  });
+
+  it("renders Authentication with a room", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={["/5"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(wrapper.find(Authentication)).toHaveLength(1);
+    expect(wrapper.find(Stats)).toHaveLength(0);
+  });
+
+  it("doesn't render Authentication with a bad URL", () => {
+    const wrapper = mount(
+      <MemoryRouter initialEntries={["/octane"]}>
+        <App />
+      </MemoryRouter>
+    );
+    expect(wrapper.find(Authentication)).toHaveLength(0);
+    expect(wrapper.find(Stats)).toHaveLength(0);
   });
 });

--- a/src/component/globalstats/Game.tsx
+++ b/src/component/globalstats/Game.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import "./css/Game.css";
+
+interface Props {
+  game: any;
+}
+
+export const Game = (props: Props) => {
+  return (
+    <span className="game">
+      <div>{"date: " + props.game.created_at}</div>
+      <div>{"time taken: " + props.game.time + " seconds"}</div>
+      <div>{"WPM: " + props.game.wpm}</div>
+      <div>{"accuracy: " + props.game.accuracy + "%"}</div>
+      <div>{"mistakes: " + props.game.mistakes}</div>
+      <div>{"words typed: " + props.game.words_typed}</div>
+      <div>{"letters typed: " + props.game.letters_typed}</div>
+    </span>
+  );
+};

--- a/src/component/globalstats/Stats.tsx
+++ b/src/component/globalstats/Stats.tsx
@@ -1,2 +1,47 @@
 import * as React from "react";
-export const Stats = () => <>place stats here</>;
+import { useState, useEffect } from "react";
+import { fetchGlobalStatsAPI } from "./api/fetchGlobalStatsAPI";
+import { Game } from "./Game";
+import "./css/Stats.css";
+
+export const Stats = () => {
+  const [globalStats, setGlobalStats] = useState<any>(false);
+
+  useEffect(() => {
+    fetchGlobalStatsAPI(setGlobalStats);
+  }, []);
+
+  const displayGameHistory = () =>
+    globalStats.games_played.map((game: any, index: number) => (
+      <Game key={index} game={game} />
+    ));
+
+  const displayStats = () => {
+    return (
+      <>
+        <div>{"average accuracy: " + globalStats.stats.average_accuracy}</div>
+        <div>
+          {"average letters typed: " + globalStats.stats.average_letters_typed}
+        </div>
+        <div>{"average mistakes: " + globalStats.stats.average_mistakes}</div>
+        <div>
+          {"average words typed: " + globalStats.stats.average_words_typed}
+        </div>
+        <div>{"average WPM: " + globalStats.stats.average_wpm}</div>
+        <div>
+          {"total letters typed: " + globalStats.stats.total_letters_typed}
+        </div>
+        <div>{"total mistakes: " + globalStats.stats.total_mistakes}</div>
+        <div>{"total words typed: " + globalStats.stats.total_words_typed}</div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      {globalStats && displayStats()}
+      <div className="title">{globalStats && "Game History"}</div>
+      <div className="history">{globalStats && displayGameHistory()}</div>
+    </>
+  );
+};

--- a/src/component/globalstats/__tests__/Game.test.tsx
+++ b/src/component/globalstats/__tests__/Game.test.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { Game } from "../Game";
+import renderer from "react-test-renderer";
+
+describe("Game", () => {
+  let game = {
+    created_at: "Monday",
+    time: 3,
+    wpm: 15,
+    accuracy: 100,
+    mistakes: 0,
+    words_typed: 4,
+    letters_typed: 20
+  };
+
+  it("renders a game", () => {
+    const tree = renderer.create(<Game game={game} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/component/globalstats/__tests__/Stats.test.tsx
+++ b/src/component/globalstats/__tests__/Stats.test.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { Stats } from "../Stats";
+import renderer from "react-test-renderer";
+
+describe("Stats", () => {
+  it("does nothing yet", () => {
+    //
+  });
+});

--- a/src/component/globalstats/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/component/globalstats/__tests__/__snapshots__/Game.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Game renders a game 1`] = `
+<span
+  className="game"
+>
+  <div>
+    date: Monday
+  </div>
+  <div>
+    time taken: 3 seconds
+  </div>
+  <div>
+    WPM: 15
+  </div>
+  <div>
+    accuracy: 100%
+  </div>
+  <div>
+    mistakes: 0
+  </div>
+  <div>
+    words typed: 4
+  </div>
+  <div>
+    letters typed: 20
+  </div>
+</span>
+`;

--- a/src/component/globalstats/api/fetchGlobalStatsAPI.ts
+++ b/src/component/globalstats/api/fetchGlobalStatsAPI.ts
@@ -1,0 +1,13 @@
+export async function fetchGlobalStatsAPI(setGlobalStats: any) {
+  let uuid = sessionStorage.getItem("uuid");
+
+  await fetch("http://localhost:3000/api/players_rooms/", {
+    method: "GET",
+    mode: "cors",
+    headers: { uuid: JSON.stringify(uuid) }
+  })
+    .then(result => result.json())
+    .then(result => {
+      setGlobalStats(result);
+    });
+}

--- a/src/component/globalstats/css/Game.css
+++ b/src/component/globalstats/css/Game.css
@@ -1,0 +1,6 @@
+.game {
+  float: left;
+  padding-top: 10px;
+  padding-right: 6px;
+  border: 5px solid red;
+}

--- a/src/component/globalstats/css/Stats.css
+++ b/src/component/globalstats/css/Stats.css
@@ -1,0 +1,14 @@
+.title {
+  border: 5px solid turquoise;
+}
+
+.history {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  text-align: left;
+  margin-left: auto;
+  margin-right: auto;
+  border: 5px solid orange;
+  width: 75%;
+}


### PR DESCRIPTION
By hitting an api endpoint to build a stats payload for a player we can
display their global stats. We can then use this information and some
sort of Javascript graph library to build graphs.

I would like to put the stats page into some sort of navbar at the top.

At the moment we just use a flex box to render all game history and wrap
accordingly but it would be nice to put the games into some sort of
scrolling box and display them as rows.

I also need to figure out how to test API endpoints in React. The other
files that utilize endpoints need tests as well.