### PR TITLE
Add dependency to allow session storage in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7421,6 +7421,12 @@
         "pretty-format": "^24.8.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz",
+      "integrity": "sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     ]
   },
   "devDependencies": {
+    "jest-localstorage-mock": "^2.4.0",
     "prettier": "1.18.2"
+  },
+  "jest": {
+    "setupTestFrameworkScriptFile": "./src/setupTests.js"
   }
 }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,6 @@
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  clear: jest.fn()
+};
+global.localStorage = localStorageMock;


### PR DESCRIPTION
We need to be able to manipulate the session storage in tests. We can
use this package to do that, and will eventually mock API calls that
cause our session storage to change, which affects how our application
renders.