### PR TITLE
Rate limit position updates and race renders

### DIFF
--- a/src/component/Board.tsx
+++ b/src/component/Board.tsx
@@ -17,6 +17,7 @@ interface Props {
   endGame: () => boolean;
   checkLetter: () => void;
   updateStats: (newStats: any) => void;
+  setMakeRequests: (newRequest: boolean) => void;
   currentWordIndex: number;
   finishTime: number;
   incorrectLetters: number;
@@ -59,6 +60,7 @@ export const Board = (props: Props) => {
       updateCountDown={props.updateCountDown}
       countUp={props.countUp}
       setCountUp={props.setCountUp}
+      setMakeRequests={props.setMakeRequests}
       countDown={props.countDown}
       setCountDown={props.setCountDown}
     />

--- a/src/component/Game.tsx
+++ b/src/component/Game.tsx
@@ -7,6 +7,7 @@ interface Props {
   setCountDown: (newCountDown: boolean) => void;
   updateCountDown: (newCountDown: boolean) => void;
   updateStats: (newStats: any) => void;
+  setMakeRequests: (newRequest: boolean) => void;
   raceState: any;
   statsState: any;
   name: string;
@@ -83,6 +84,7 @@ export const Game = (props: Props) => {
           ID={props.ID}
           updateStats={props.updateStats}
           statsState={props.statsState}
+          setMakeRequests={props.setMakeRequests}
         />
       }
     </>

--- a/src/component/race/Race.tsx
+++ b/src/component/race/Race.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Player } from "./Player";
+import { useState } from "react";
 import "./css/Race.css";
 
 interface Props {
@@ -12,6 +13,8 @@ interface Props {
 }
 
 export const Race = (props: Props) => {
+  const [currentPosition, setCurrentPosition] = useState<number>(0);
+
   const generateRace = () =>
     props.raceState.players.map((player: any, index: number) => (
       <Player key={index} position={player.position} name={player.name} />
@@ -21,18 +24,23 @@ export const Race = (props: Props) => {
     let new_position: number = Math.round(
       (props.currentWordIndex / props.wordsLength) * 100
     );
-    let old_position: number = props.raceState.players.find(byID).position;
 
-    if (old_position !== new_position) {
+    // let old_position: number = props.raceState.players.find(byID).position;
+
+    if (
+      new_position > currentPosition + 10 ||
+      (new_position === 100 && new_position !== currentPosition)
+    ) {
+      setCurrentPosition(new_position);
       props.updatePosition(new_position);
     }
   };
 
-  const byID = (player: any) => {
-    if (player.id === props.ID) {
-      return player;
-    }
-  };
+  // const byID = (player: any) => {
+  //   if (player.id === props.ID) {
+  //     return player;
+  //   }
+  // };
 
   const raceStart = () => {
     if (props.raceState !== null) {

--- a/src/component/timer/CountUpTimer.tsx
+++ b/src/component/timer/CountUpTimer.tsx
@@ -4,12 +4,14 @@ import "./css/CountUpTimer.css";
 
 interface Props {
   setFinishTime: (newTime: number) => void;
+  setMakeRequests: (newRequests: boolean) => void;
 }
 
 export const CountUpTimer = (props: Props) => {
   const [seconds, setSeconds] = useState<number>(0);
 
   useEffect(() => {
+    props.setMakeRequests(true);
     let timerID = setTimeout(tick, 1000);
 
     return function cleanup() {

--- a/src/component/timer/Timer.tsx
+++ b/src/component/timer/Timer.tsx
@@ -10,6 +10,7 @@ interface Props {
   countDown: boolean;
   countUp: boolean;
   setFinishTime: (newFinishTime: number) => void;
+  setMakeRequests: (newRequest: boolean) => void;
 }
 
 export const Timer = (props: Props) => {
@@ -18,7 +19,10 @@ export const Timer = (props: Props) => {
   );
 
   const renderCountUpTimer = () => (
-    <CountUpTimer setFinishTime={props.setFinishTime} />
+    <CountUpTimer
+      setMakeRequests={props.setMakeRequests}
+      setFinishTime={props.setFinishTime}
+    />
   );
 
   const handleEvent = () => {

--- a/src/component/timer/__tests__/CountUpTimer.test.tsx
+++ b/src/component/timer/__tests__/CountUpTimer.test.tsx
@@ -5,23 +5,37 @@ import renderer from "react-test-renderer";
 describe("CountUpTimer", () => {
   jest.useFakeTimers();
   const setFinishTime = jest.fn();
+  const setMakeRequests = jest.fn();
 
   it("renders the CountUpTimer", () => {
     const tree = renderer
-      .create(<CountUpTimer setFinishTime={setFinishTime} />)
+      .create(
+        <CountUpTimer
+          setMakeRequests={setMakeRequests}
+          setFinishTime={setFinishTime}
+        />
+      )
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it("calls tick every 1000 miliseconds", () => {
     const TimerComponent = renderer.create(
-      <CountUpTimer setFinishTime={setFinishTime} />
+      <CountUpTimer
+        setMakeRequests={setMakeRequests}
+        setFinishTime={setFinishTime}
+      />
     );
 
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
     expect(setTimeout).toHaveBeenCalledTimes(1);
 
-    TimerComponent.update(<CountUpTimer setFinishTime={setFinishTime} />);
+    TimerComponent.update(
+      <CountUpTimer
+        setMakeRequests={setMakeRequests}
+        setFinishTime={setFinishTime}
+      />
+    );
 
     expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
     expect(setTimeout).toHaveBeenCalledTimes(2);
@@ -29,7 +43,10 @@ describe("CountUpTimer", () => {
 
   it("sets the finish time when unmounted", () => {
     const TimerComponent = renderer.create(
-      <CountUpTimer setFinishTime={setFinishTime} />
+      <CountUpTimer
+        setMakeRequests={setMakeRequests}
+        setFinishTime={setFinishTime}
+      />
     );
     TimerComponent.unmount();
 

--- a/src/component/timer/__tests__/Timer.test.tsx
+++ b/src/component/timer/__tests__/Timer.test.tsx
@@ -12,6 +12,7 @@ describe("Timer", () => {
   const setCountDown = jest.fn();
   const setCountUp = jest.fn();
   const updateCountDown = jest.fn();
+  const setMakeRequests = jest.fn();
 
   const buildProps = (newProps = {}) => ({
     setCountDown,
@@ -20,6 +21,7 @@ describe("Timer", () => {
     countDown: false,
     countUp: false,
     setFinishTime,
+    setMakeRequests,
     ...newProps
   });
 

--- a/src/component/websocket/WebsocketController.tsx
+++ b/src/component/websocket/WebsocketController.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Game } from "../Game";
 import Websocket from "react-websocket";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import "./css/WebsocketController.css";
 
 interface Props {
@@ -19,6 +19,22 @@ export const WebsocketController = (props: Props) => {
   const [countDown, setCountDown] = useState<boolean>(false);
   const [uuid] = useState<any>(sessionStorage.getItem("uuid"));
   const [gameInProgress, setGameInProgress] = useState<boolean>(false);
+  const [makeRequests, setMakeRequests] = useState<boolean>(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => makeRequests && requestState(), 2000);
+    return () => clearInterval(interval);
+  });
+
+  const requestState = () => {
+    console.log("in state  request)");
+    var stateRequest = {
+      type: "state_request",
+      uuid: uuid
+    };
+
+    sendMessage(stateRequest);
+  };
 
   const handleData = (data: any) => {
     let update = JSON.parse(data);
@@ -32,6 +48,7 @@ export const WebsocketController = (props: Props) => {
       setCountDown(update.countdown);
     } else if (update.type === "stats") {
       setStatsState(update);
+      setMakeRequests(false);
     } else if (update.type === "game_started") {
       setGameInProgress(true);
     }
@@ -121,6 +138,7 @@ export const WebsocketController = (props: Props) => {
           name={name}
           raceState={raceState}
           ID={ID}
+          setMakeRequests={setMakeRequests}
         />
       )}
     </>


### PR DESCRIPTION
Testing this in prod achieved the desired results with 2 people, where
there had previously been issues.

We can use state to keep track of our old position rather than checking
for it. We can ensure that we only send our new position to the server
when we've progressed 10%.

I spent the day trying to figure out different ways and tricks in React
to achieve all of this and was only semi-successful. I've opted to ask
the server every 2 seconds for a race update. I'm not entirely sure
how I would go about achieving this on the server without having the
client ask for it because some sort of game loop would lock up the
Controller to the multitude of other requests being processed.

So, we can start making requests every 2 seconds when the game has
started, and stop when the game is over. While that is happening we
only send our updates every 10%. It's worth a shot.