### PR TITLE
Turn game history into scrollable table

### DIFF
--- a/src/component/globalstats/Game.tsx
+++ b/src/component/globalstats/Game.tsx
@@ -5,28 +5,39 @@ interface Props {
   game: any;
 }
 
-export const Game = (props: Props) => {
-  return (
-    <div className="game">
-      <span className="individualhistory">
-        {"date: " + props.game.created_at}
-      </span>
-      <span className="individualhistory">
-        {"time taken: " + props.game.time + " seconds"}
-      </span>
-      <span className="individualhistory">{"WPM: " + props.game.wpm}</span>
-      <span className="individualhistory">
-        {"accuracy: " + props.game.accuracy + "%"}
-      </span>
-      <span className="individualhistory">
-        {"mistakes: " + props.game.mistakes}
-      </span>
-      <span className="individualhistory">
-        {"words typed: " + props.game.words_typed}
-      </span>
-      <span className="individualhistory">
-        {"letters typed: " + props.game.letters_typed}
-      </span>
-    </div>
-  );
-};
+export const Game = (props: Props) => (
+  <>
+    <tr>
+      <th>
+        <div>Date</div>
+      </th>
+      <th>
+        <div>Time</div>
+      </th>
+      <th>
+        <div>WPM</div>
+      </th>
+      <th>
+        <div>Accuracy</div>
+      </th>
+      <th>
+        <div>Mistakes</div>
+      </th>
+      <th>
+        <div>Words</div>
+      </th>
+      <th>
+        <div>Letters</div>
+      </th>
+    </tr>
+    <tr>
+      <td>{props.game.created_at}</td>
+      <td>{props.game.time + " seconds"}</td>
+      <td>{props.game.wpm}</td>
+      <td>{props.game.accuracy + "%"}</td>
+      <td>{props.game.mistakes}</td>
+      <td>{props.game.words_typed}</td>
+      <td>{props.game.letters_typed}</td>
+    </tr>
+  </>
+);

--- a/src/component/globalstats/Stats.tsx
+++ b/src/component/globalstats/Stats.tsx
@@ -49,7 +49,11 @@ export const Stats = () => {
   return (
     <>
       <div className="title">{globalStats && "Game History"}</div>
-      <div className="history">{globalStats && displayGameHistory()}</div>
+      <div className="scrolltable">
+        <table className="scrolltable__history">
+          {globalStats && displayGameHistory()}
+        </table>
+      </div>
       <div className="globalstats">{globalStats && displayStats()}</div>
       <div className="graph">
         {globalStats && <Graph gamesPlayed={globalStats.games_played} />}

--- a/src/component/globalstats/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/component/globalstats/__tests__/__snapshots__/Game.test.tsx.snap
@@ -1,43 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Game renders a game 1`] = `
-<div
-  className="game"
->
-  <span
-    className="individualhistory"
-  >
-    date: Monday
-  </span>
-  <span
-    className="individualhistory"
-  >
-    time taken: 3 seconds
-  </span>
-  <span
-    className="individualhistory"
-  >
-    WPM: 15
-  </span>
-  <span
-    className="individualhistory"
-  >
-    accuracy: 100%
-  </span>
-  <span
-    className="individualhistory"
-  >
-    mistakes: 0
-  </span>
-  <span
-    className="individualhistory"
-  >
-    words typed: 4
-  </span>
-  <span
-    className="individualhistory"
-  >
-    letters typed: 20
-  </span>
-</div>
+Array [
+  <tr>
+    <th>
+      <div>
+        Date
+      </div>
+    </th>
+    <th>
+      <div>
+        Time
+      </div>
+    </th>
+    <th>
+      <div>
+        WPM
+      </div>
+    </th>
+    <th>
+      <div>
+        Accuracy
+      </div>
+    </th>
+    <th>
+      <div>
+        Mistakes
+      </div>
+    </th>
+    <th>
+      <div>
+        Words
+      </div>
+    </th>
+    <th>
+      <div>
+        Letters
+      </div>
+    </th>
+  </tr>,
+  <tr>
+    <td>
+      Monday
+    </td>
+    <td>
+      3 seconds
+    </td>
+    <td>
+      15
+    </td>
+    <td>
+      100%
+    </td>
+    <td>
+      0
+    </td>
+    <td>
+      4
+    </td>
+    <td>
+      20
+    </td>
+  </tr>,
+]
 `;

--- a/src/component/globalstats/css/Game.css
+++ b/src/component/globalstats/css/Game.css
@@ -1,12 +1,9 @@
-.game {
-  float: right;
-  margin-left: 5px;
-  margin-right: 5px;
-  padding-top: 10px;
-  padding-right: 6px;
-  padding-bottom: 10px;
+th {
+  width: 15%;
+  padding-top: 0.3%;
 }
 
-.individualhistory {
-  padding: 8px;
+td {
+  padding-bottom: 0.3%;
+  border-bottom: 1px solid black;
 }

--- a/src/component/globalstats/css/Stats.css
+++ b/src/component/globalstats/css/Stats.css
@@ -25,18 +25,19 @@
   padding: 10px;
 }
 
-.history {
+.scrolltable {
   overflow: auto;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  text-align: left;
+  height: 250px;
+  width: 75%;
   margin-left: auto;
   margin-right: auto;
-  border: 5px solid black;
-  width: 75%;
-  height: 200px;
   background-color: white;
+  border: 5px solid black;
+  text-align: center;
+}
+
+.scrolltable__history {
+  width: 100%;
 }
 
 .graph {


### PR DESCRIPTION
This makes it easy to see individual game stats.

Another idea would be to have one row of <th> elements that is always
visible and have the game stats scrollable underneath them.

![Screen Shot 2019-08-28 at 10 27 11 AM](https://user-images.githubusercontent.com/28407708/63878751-1614c400-c97f-11e9-88e3-b7d318555461.png)
