### PR TITLE
Format date/time in Game history

### DIFF
--- a/src/component/globalstats/Game.tsx
+++ b/src/component/globalstats/Game.tsx
@@ -5,39 +5,45 @@ interface Props {
   game: any;
 }
 
-export const Game = (props: Props) => (
-  <>
-    <tr>
-      <th>
-        <div>Date</div>
-      </th>
-      <th>
-        <div>Time</div>
-      </th>
-      <th>
-        <div>WPM</div>
-      </th>
-      <th>
-        <div>Accuracy</div>
-      </th>
-      <th>
-        <div>Mistakes</div>
-      </th>
-      <th>
-        <div>Words</div>
-      </th>
-      <th>
-        <div>Letters</div>
-      </th>
-    </tr>
-    <tr>
-      <td>{props.game.created_at}</td>
-      <td>{props.game.time + " seconds"}</td>
-      <td>{props.game.wpm}</td>
-      <td>{props.game.accuracy + "%"}</td>
-      <td>{props.game.mistakes}</td>
-      <td>{props.game.words_typed}</td>
-      <td>{props.game.letters_typed}</td>
-    </tr>
-  </>
-);
+export const Game = (props: Props) => {
+  const buildDate = () => {
+    let timestamp = new Date(Date.parse(props.game.created_at));
+    return timestamp.toDateString() + "\n" + timestamp.toLocaleTimeString();
+  };
+  return (
+    <tbody>
+      <tr>
+        <th>
+          <div>Date</div>
+        </th>
+        <th>
+          <div>Time</div>
+        </th>
+        <th>
+          <div>WPM</div>
+        </th>
+        <th>
+          <div>Accuracy</div>
+        </th>
+        <th>
+          <div>Mistakes</div>
+        </th>
+        <th>
+          <div>Words</div>
+        </th>
+        <th>
+          <div>Letters</div>
+        </th>
+      </tr>
+      <tr>
+        <td>{buildDate()}</td>
+        <td>{props.game.time + " seconds"}</td>
+        <td>{props.game.wpm}</td>
+        <td>{props.game.accuracy + "%"}</td>
+        <td>{props.game.mistakes}</td>
+        <td>{props.game.words_typed}</td>
+        <td>{props.game.letters_typed}</td>
+      </tr>
+    </tbody>
+  );
+};

--- a/src/component/globalstats/Stats.tsx
+++ b/src/component/globalstats/Stats.tsx
@@ -19,26 +19,28 @@ export const Stats = () => {
 
   const displayStats = () => (
     <table className="globalstats">
-      <tr>
-        <th>Average accuracy</th>
-        <th>Average mistakes</th>
-        <th>Average words</th>
-        <th>Average letters</th>
-        <th>Average WPM</th>
-        <th>Total words</th>
-        <th>Total letters</th>
-        <th>Total mistakes</th>
-      </tr>
-      <tr>
-        <td>{globalStats.stats.average_accuracy + "%"}</td>
-        <td>{globalStats.stats.average_mistakes}</td>
-        <td>{globalStats.stats.average_words_typed}</td>
-        <td>{globalStats.stats.average_letters_typed}</td>
-        <td>{globalStats.stats.average_wpm}</td>
-        <td>{globalStats.stats.total_words_typed}</td>
-        <td>{globalStats.stats.total_letters_typed}</td>
-        <td>{globalStats.stats.total_mistakes}</td>
-      </tr>
+      <tbody>
+        <tr>
+          <th>Average accuracy</th>
+          <th>Average mistakes</th>
+          <th>Average words</th>
+          <th>Average letters</th>
+          <th>Average WPM</th>
+          <th>Total words</th>
+          <th>Total letters</th>
+          <th>Total mistakes</th>
+        </tr>
+        <tr>
+          <td>{globalStats.stats.average_accuracy + "%"}</td>
+          <td>{globalStats.stats.average_mistakes}</td>
+          <td>{globalStats.stats.average_words_typed}</td>
+          <td>{globalStats.stats.average_letters_typed}</td>
+          <td>{globalStats.stats.average_wpm}</td>
+          <td>{globalStats.stats.total_words_typed}</td>
+          <td>{globalStats.stats.total_letters_typed}</td>
+          <td>{globalStats.stats.total_mistakes}</td>
+        </tr>
+      </tbody>
     </table>
   );
 

--- a/src/component/globalstats/__tests__/__snapshots__/Game.test.tsx.snap
+++ b/src/component/globalstats/__tests__/__snapshots__/Game.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Game renders a game 1`] = `
-Array [
+<tbody>
   <tr>
     <th>
       <div>
@@ -38,10 +38,11 @@ Array [
         Letters
       </div>
     </th>
-  </tr>,
+  </tr>
   <tr>
     <td>
-      Monday
+      Invalid Date
+Invalid Date
     </td>
     <td>
       3 seconds
@@ -61,6 +62,6 @@ Array [
     <td>
       20
     </td>
-  </tr>,
-]
+  </tr>
+</tbody>
 `;


### PR DESCRIPTION
Now we will see the Date listed as (for example):
Tue Aug 27 2019 2:49:17 PM

instead of:
2019-08-27 20:05:26 UTC

Also add <tbody> tags as the browser was complaining.

![Screen Shot 2019-08-28 at 2 42 51 PM](https://user-images.githubusercontent.com/28407708/63894693-25f1cf80-c9a2-11e9-9eea-1c5a0baaa40a.png)
