### PR TITLE
Make one last state request before sending stats

### DIFF
--- a/src/component/websocket/WebsocketController.tsx
+++ b/src/component/websocket/WebsocketController.tsx
@@ -27,7 +27,6 @@ export const WebsocketController = (props: Props) => {
   });
 
   const requestState = () => {
-    console.log("in state  request)");
     var stateRequest = {
       type: "state_request",
       uuid: uuid
@@ -48,6 +47,7 @@ export const WebsocketController = (props: Props) => {
       setCountDown(update.countdown);
     } else if (update.type === "stats") {
       setStatsState(update);
+      requestState();
       setMakeRequests(false);
     } else if (update.type === "game_started") {
       setGameInProgress(true);


### PR DESCRIPTION
Because we have put a delay on how often you update your position to
the server and receive updates, we need to make sure we send out our
last update at position=100 right before we ask for stats. This ensures
that you don't stop earlier than being 100% finished. If you type too
fast without this then the last thing the server sees from you will be
something less than 100.