### PR TITLE
Add max character limit to typing box

### DIFF
--- a/src/component/Game.tsx
+++ b/src/component/Game.tsx
@@ -52,7 +52,10 @@ export const Game = (props: Props) => {
   };
 
   const checkLetter = () => {
-    if (currentInput !== getCurrentWordSubstring()) {
+    if (
+      currentInput !== getCurrentWordSubstring() &&
+      currentInput.length !== 11
+    ) {
       setIncorrectLetters(incorrectLetters + 1);
     }
     return;

--- a/src/component/typingbox/TypingBox.tsx
+++ b/src/component/typingbox/TypingBox.tsx
@@ -48,6 +48,7 @@ export const TypingBox = (props: Props) => {
       onKeyUp={detectBackspace}
       onKeyDown={detectSpace}
       onChange={handleChange}
+      maxLength={11}
     />
   );
 };

--- a/src/component/typingbox/__tests__/__snapshots__/TypingBox.test.tsx.snap
+++ b/src/component/typingbox/__tests__/__snapshots__/TypingBox.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`TypingBox renders an input field 1`] = `
 <input
   className="box"
+  maxLength={11}
   onChange={[Function]}
   onKeyDown={[Function]}
   onKeyUp={[Function]}


### PR DESCRIPTION
This will stop players from making a mistake and then continuing to type
limitless characters, racking up their mistakes, before they notice
that they are typing incorrectly.

Having a hard-coded value means that we need to make sure we don't
introduce words that are larger than 11 characters though.

An alternative to this could be introduced when we pull text from the
server, that the server also send over a proper max character count.

Another alternative would be to find the largest string in the text and
add a bunch to its length and set that as the max.

For the sake of demo-ing this, I will just hard code a max length and
ensure that I don't add words that are too long.