### PR TITLE
Add cleanup for timer

### DIFF
--- a/src/component/timer/CountUpTimer.tsx
+++ b/src/component/timer/CountUpTimer.tsx
@@ -15,6 +15,7 @@ export const CountUpTimer = (props: Props) => {
     let timerID = setTimeout(tick, 1000);
 
     return function cleanup() {
+      clearTimeout(timerID);
       props.setFinishTime(seconds);
     };
   });


### PR DESCRIPTION
This bug has existed for months but only now do I understand how to
fix it. Basically an update was trying to be performed on a component
that was unmounted (this timer) and we needed to clear the timeout
when the timer was finished so that it doesn't try to update.